### PR TITLE
Enhance docs homepage with component category cards

### DIFF
--- a/content/overview/introduction.mdx
+++ b/content/overview/introduction.mdx
@@ -59,6 +59,27 @@ Buttons and inputs must always have the same height. When a button sits next to 
 
 This is enforced at the token level via `h-control`, which maps to `--height-control`. Changing one automatically changes both.
 
+### Sizing system: default, compact, and responsive
+
+Every component in SolarUI is designed around two intentional size modes:
+
+**Default** is the baseline. It gives each component breathing room — comfortable padding, readable text, and touch targets large enough to be usable. This is what you get out of the box.
+
+**Compact** is a denser variant. Every component becomes narrower and tighter, without losing legibility or accessibility. It is designed for power-user interfaces, data-heavy dashboards, or any context where screen real estate matters more than comfort.
+
+These two modes are not just stylistic — they are structural. Switching from default to compact adjusts spacing, height, and typography tokens across all components at once. Nothing needs to be overridden individually.
+
+Beyond those two modes, the system is also **responsive by nature**. Components adapt their size depending on the screen they are rendered on. A button on mobile is larger — its hit area needs to be accessible to a finger. The same button on desktop is slightly smaller and more refined, because a cursor is precise and space is less constrained.
+
+This is not done through arbitrary breakpoint overrides. It is built into the token system: each size token resolves to a different value depending on the viewport, so all components scale together consistently.
+
+| Context | Philosophy |
+|---------|------------|
+| Mobile | Larger targets, more accessible to touch |
+| Desktop | Tighter and more refined, optimized for cursor precision |
+| Compact mode | Dense layout for data-heavy or expert interfaces |
+| Default mode | Comfortable baseline for general use |
+
 ### Group, categorize, order
 
 At Solar, we pay careful attention to how components and icons are sorted and grouped. This is not an aesthetic concern — it is a structural decision.


### PR DESCRIPTION
Add full component directory to the homepage, organized by category
(Action, Form, Feedback, Layout, Content, Navigation, Data, Chart)
with individual cards linking to each component page. Also adds
Overview, Foundation, Theming, and Core sections for quick access.

https://claude.ai/code/session_01TXRTf4U1eUD7ELQqK2Dv4w