### PR TITLE
docs: add v0.1.1 changelog entry with documentation improvements

### DIFF
--- a/content/overview/changelog.mdx
+++ b/content/overview/changelog.mdx
@@ -10,6 +10,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.1.1] — 2026-03-16
+
+Documentation improvements across the board — no API or component changes.
+
+### Documentation
+
+- **Homepage redesign** — replaced plain navigation cards with an illustrated `DocCard` / `DocGrid` layout covering all sections (Overview, Foundation, Theming, Core, Components, Charts)
+- **Illustrated DocCard component** — each category card now ships with a custom SVG illustration; 13 illustration issues fixed after initial release
+- **Installation commands updated** — `npx shadcn@latest add` URLs corrected for all 49 component pages
+- **Sizing system section** — new *"Sizing system: default, compact, and responsive"* section added to Introduction, documenting the two intentional size modes and the responsive token strategy
+- **Responsive Do/Don't example** — the button/input alignment example in Introduction now uses an icon-only `Button` on mobile, matching real-world responsive patterns
+
+---
+
 ## [0.1.0] — 2026-03-15
 
 Initial public release of Solar UI — 68 components built on shadcn/ui, Tailwind CSS v4, and Radix UI colors.


### PR DESCRIPTION
## What does this PR do?

Adds a new changelog entry for version 0.1.1 documenting recent documentation improvements, including homepage redesign with illustrated cards, updated installation commands, new sizing system section, and responsive design examples.

## Type of change

- [ ] Bug fix
- [ ] New component
- [ ] Improvement to an existing component
- [x] Documentation
- [ ] Other (describe):

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation is added or updated in `content/`

## Notes for reviewers

This changelog entry documents the following documentation improvements made in v0.1.1:
- Homepage redesign with `DocCard` / `DocGrid` layout and custom SVG illustrations
- Corrected `npx shadcn@latest add` URLs across 49 component pages
- New "Sizing system" section in Introduction covering default, compact, and responsive modes
- Updated responsive design example in Introduction using icon-only buttons on mobile

No API or component changes are included in this release.

https://claude.ai/code/session_015EVwSPKzSUjg8xwHfdduwL