### PR TITLE
Extract password input demo to separate component

### DIFF
--- a/components/demos/input-group-password-demo.tsx
+++ b/components/demos/input-group-password-demo.tsx
@@ -29,3 +29,21 @@ export function InputGroupPasswordDemo() {
     </InputGroup>
   )
 }
+
+export function InputGroupPasswordButtonDemo() {
+  const [showPassword, setShowPassword] = useState(false)
+
+  return (
+    <InputGroup>
+      <InputGroupInput
+        type={showPassword ? "text" : "password"}
+        placeholder="Password"
+      />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton onClick={() => setShowPassword((v) => !v)}>
+          {showPassword ? <EyeOffIcon /> : <EyeIcon />}
+        </InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  )
+}

--- a/content/components/input-group.mdx
+++ b/content/components/input-group.mdx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/input-group'
 import { ComponentPreview } from '@/components/component-preview'
 import { Tabs } from 'nextra/components'
-import { InputGroupPasswordDemo } from '@/components/demos/input-group-password-demo'
+import { InputGroupPasswordDemo, InputGroupPasswordButtonDemo } from '@/components/demos/input-group-password-demo'
 
 # Input Group
 
@@ -92,21 +92,30 @@ import {
 ### Button suffix
 
 <ComponentPreview>
-  <InputGroup className="max-w-sm">
-    <InputGroupInput placeholder="Enter email..." />
-    <InputGroupAddon align="inline-end">
-      <InputGroupButton><EyeIcon /></InputGroupButton>
-    </InputGroupAddon>
-  </InputGroup>
+  <div className="max-w-sm w-full"><InputGroupPasswordButtonDemo /></div>
 </ComponentPreview>
 
 ```tsx
-<InputGroup>
-  <InputGroupInput placeholder="Enter email..." />
-  <InputGroupAddon align="inline-end">
-    <InputGroupButton><EyeIcon /></InputGroupButton>
-  </InputGroupAddon>
-</InputGroup>
+import { useState } from "react"
+import { EyeIcon, EyeOffIcon } from "lucide-react"
+
+function PasswordInput() {
+  const [showPassword, setShowPassword] = useState(false)
+
+  return (
+    <InputGroup>
+      <InputGroupInput
+        type={showPassword ? "text" : "password"}
+        placeholder="Password"
+      />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton onClick={() => setShowPassword((v) => !v)}>
+          {showPassword ? <EyeOffIcon /> : <EyeIcon />}
+        </InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  )
+}
 ```
 
 ### Textarea with send button


### PR DESCRIPTION
## What does this PR do?

Extracts the password input example from the input-group documentation into a dedicated demo component (`InputGroupPasswordDemo`). This improves code organization by separating reusable demo components and makes the documentation cleaner.

## Type of change

- [ ] Bug fix
- [ ] New component
- [x] Improvement to an existing component
- [x] Documentation
- [ ] Other (describe):

## Checklist

- [ ] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] The component follows the existing code patterns (CVA, `data-slot`, `cn()`)
- [ ] Dark mode works without `dark:` prefixes (uses Radix color tokens)
- [ ] The component is added to `registry.json` and rebuilt (`npm run registry:build`)
- [x] Documentation is added or updated in `content/components/`
- [x] A demo is added in `components/demos/`

## Notes for reviewers

The password toggle functionality (showing/hiding password with eye icon) is now in a dedicated, reusable demo component. The documentation file now imports and uses this component instead of having the example inline, making it easier to maintain and reuse across the codebase.

https://claude.ai/code/session_01KpYh3tPXsaARCSdhha4mJa