### PR TITLE
Clean up homepage hero section and fix theming link

### DIFF
--- a/app/(home)/components/FooterSection.tsx
+++ b/app/(home)/components/FooterSection.tsx
@@ -16,7 +16,7 @@ const links = [
     label: 'Resources',
     items: [
       { label: 'Installation', href: '/docs/overview/installation' },
-      { label: 'Theming', href: '/docs/theming/overview' },
+      { label: 'Theming', href: '/docs/theming/composing-palettes' },
       {
         label: 'GitHub',
         href: 'https://github.com/melvindesign/SolarUI',

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -8,14 +8,6 @@ import { DocCard, DocGrid } from '../components/docs/DocCard'
 
 SolarUI is a modern UI component library built with **React**, **Tailwind CSS**, and **shadcn/ui**. Accessible, customizable, and ready to drop into your project.
 
-<DocGrid>
-  <DocCard title="Getting Started" href="/docs/overview/introduction" description="Learn how to install and configure SolarUI in your project" illustration="getting-started" />
-  <DocCard title="Components" href="/docs/components/button" description="Browse all available UI components" illustration="components-section" />
-  <DocCard title="Foundation" href="/docs/foundation/colors" description="Design tokens, colors, and typography system" illustration="foundation-section" />
-</DocGrid>
-
----
-
 ## Overview
 
 <DocGrid>


### PR DESCRIPTION
## What does this PR do?

This PR removes the redundant DocGrid section from the homepage hero area and updates the theming documentation link in the footer to point to the correct page.

**Changes:**
- Removed the initial DocGrid with "Getting Started", "Components", and "Foundation" cards from the homepage hero section (these are duplicated in the Overview section below)
- Updated the "Theming" footer link from `/docs/theming/overview` to `/docs/theming/composing-palettes` to point to the correct documentation page

## Type of change

- [ ] Bug fix
- [x] Documentation
- [ ] Other (describe): Homepage cleanup and navigation fix

## Checklist

- [x] Documentation is updated

## Notes for reviewers

The removal of the duplicate DocGrid simplifies the homepage hero section and reduces redundancy. The theming link update ensures users are directed to the actual theming documentation page rather than a non-existent overview page.

https://claude.ai/code/session_01TzpsW8HNFhyVCJxYC3aEei