### PR TITLE
feat: add install command copy input to hero section

### DIFF
--- a/app/(home)/components/HeroSection.tsx
+++ b/app/(home)/components/HeroSection.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Github } from 'lucide-react'
 import Link from 'next/link'
+import InstallCommand from './InstallCommand'
 
 const anim = (delay: number) => ({
   animation: `hero-fade-in 0.6s ease-out both`,
@@ -69,6 +70,11 @@ export default function HeroSection() {
             </Link>
           </Button>
         </div>
+      </div>
+
+      {/* Install command */}
+      <div style={anim(320)} className="mt-6 w-full max-w-lg">
+        <InstallCommand />
       </div>
 
     </section>

--- a/app/(home)/components/InstallCommand.tsx
+++ b/app/(home)/components/InstallCommand.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { Check, Copy } from 'lucide-react'
+import { useState } from 'react'
+
+const COMMAND = 'npx shadcn@latest add https://solar-ui.com/r/solar-ui.json'
+
+export default function InstallCommand() {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(COMMAND)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="flex items-center gap-0 rounded-lg border border-[var(--gray-6)] bg-[var(--gray-2)] px-4 py-2.5 font-mono text-sm text-[var(--gray-11)]">
+      <span className="flex-1 select-all truncate">{COMMAND}</span>
+      <button
+        onClick={handleCopy}
+        aria-label="Copy install command"
+        className="ml-3 shrink-0 rounded-md p-1 text-[var(--gray-9)] transition-colors hover:bg-[var(--gray-4)] hover:text-[var(--gray-12)]"
+      >
+        {copied ? <Check size={15} className="text-[var(--green-9)]" /> : <Copy size={15} />}
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds a read-only monospace input below the "Browse Components" and "GitHub" buttons on the landing page
- Displays the shadcn install command: `npx shadcn@latest add https://solar-ui.com/r/solar-ui.json`
- Copy button switches to a green checkmark for 2 seconds on click, then resets

## Test plan

- [x] La commande est visible sous les boutons CTA sur la landing page
- [x] Clic sur l'icône copie → icône passe en ✓ vert 2s puis revient
- [x] Coller dans un éditeur confirme que la commande complète est copiée
- [x] Le texte est sélectionnable au clic

🤖 Generated with [Claude Code](https://claude.com/claude-code)