### PR TITLE
feat(textarea): redesign with gradient background and gradient border

### DIFF
--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-default-7 bg-default-3 focus-visible:border-default-8 focus-visible:ring-default-7 aria-invalid:ring-error-7 aria-invalid:border-error-8 disabled:bg-default-3 rounded-lg border bg-transparent px-2.5 py-2 text-base transition-colors focus-visible:ring-3 aria-invalid:ring-3 md:text-sm flex field-sizing-content min-h-16 w-full outline-none placeholder:text-default-11 disabled:cursor-not-allowed disabled:opacity-50",
+        "w-full min-w-0 rounded-lg border border-transparent px-3 py-3 text-sm font-light tracking-[0.4px] transition-colors outline-none placeholder:text-default-11 text-default-12 [background:linear-gradient(to_top,var(--color-default-2),var(--color-default-1))_padding-box,linear-gradient(to_bottom,var(--color-default-8),var(--color-default-6))_border-box] focus-visible:ring-3 focus-visible:ring-default-7 aria-invalid:ring-3 aria-invalid:ring-error-7 aria-invalid:[background:linear-gradient(to_top,var(--color-default-2),var(--color-default-1))_padding-box,linear-gradient(to_bottom,var(--color-error-7),var(--color-error-7))_border-box] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 disabled:[background:var(--color-default-3)] field-sizing-content min-h-16",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

- Aligne le design de la `Textarea` sur celui de l'`Input` (gradient background + gradient border)
- Met à jour la typographie : `font-light`, `tracking-[0.4px]`, `text-sm`, `text-default-12`
- États `focus-visible`, `aria-invalid` et `disabled` cohérents avec le composant `Input`

## Test plan

- [ ] Default : border gradient visible, fond léger gradient
- [ ] Focus : ring autour du champ au clic
- [ ] Placeholder : texte gris clair, même style que l'input
- [ ] Saisie : texte `text-default-12`, `font-light`
- [ ] Disabled : fond plat `default-3`, opacité 50%, curseur `not-allowed`
- [ ] Cohérence visuelle avec `/docs/components/input`

🤖 Generated with [Claude Code](https://claude.com/claude-code)