### PR TITLE
feat(input-group): redesign with gradient background and gradient border

### DIFF
--- a/components/ui/input-group.tsx
+++ b/components/ui/input-group.tsx
@@ -14,7 +14,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="input-group"
       role="group"
       className={cn(
-        "border-default-7 has-[[data-slot=input-group-control]:focus-visible]:border-default-8 has-[[data-slot=input-group-control]:focus-visible]:ring-default-7 has-[[data-slot][aria-invalid=true]]:ring-error-7 has-[[data-slot][aria-invalid=true]]:border-error-8 has-disabled:bg-default-3 h-8 rounded-lg border transition-colors in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-3 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5 group/input-group relative flex w-full min-w-0 items-center outline-none has-[>textarea]:h-auto",
+        "rounded-lg border border-transparent [background:linear-gradient(to_top,var(--color-default-2),var(--color-default-1))_padding-box,linear-gradient(to_bottom,var(--color-default-8),var(--color-default-6))_border-box] has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-default-7 has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-error-7 has-[[data-slot][aria-invalid=true]]:[background:linear-gradient(to_top,var(--color-default-2),var(--color-default-1))_padding-box,linear-gradient(to_bottom,var(--color-error-7),var(--color-error-7))_border-box] has-disabled:[background:var(--color-default-3)] has-disabled:opacity-50 h-[39px] transition-colors in-data-[slot=combobox-content]:focus-within:ring-0 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5 group/input-group relative flex w-full min-w-0 items-center outline-none has-[>textarea]:h-auto",
         className
       )}
       {...props}
@@ -118,7 +118,7 @@ function InputGroupInput({
   return (
     <Input
       data-slot="input-group-control"
-      className={cn("rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent flex-1", className)}
+      className={cn("rounded-none border-0 [background:transparent] shadow-none ring-0 focus-visible:ring-0 disabled:[background:transparent] aria-invalid:ring-0 flex-1", className)}
       {...props}
     />
   )
@@ -131,7 +131,7 @@ function InputGroupTextarea({
   return (
     <Textarea
       data-slot="input-group-control"
-      className={cn("rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent flex-1 resize-none", className)}
+      className={cn("rounded-none border-0 [background:transparent] py-2 shadow-none ring-0 focus-visible:ring-0 disabled:[background:transparent] aria-invalid:ring-0 flex-1 resize-none", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary

- Replace old solid border (`border-default-7`) with the gradient border technique used across other form components (`Input`, `Textarea`, `InputOTP`)
- Apply gradient background via `padding-box` / `border-box` background shorthand on the `InputGroup` container
- Fix `InputGroupInput` and `InputGroupTextarea`: replace `bg-transparent` with `[background:transparent]` to correctly override the `Input`/`Textarea` internal gradient background
- Align container height from `h-8` to `h-[39px]` to match sibling components
- States preserved: focus ring (`ring-default-7`), invalid ring + border (`ring-error-7`), disabled solid bg (`default-3` + opacity 50%)

## Test plan

- [x] Default: gradient border visible (default-8 → default-6), gradient background
- [x] Focus: ring-3 ring-default-7 around the full container
- [x] Invalid: ring-3 ring-error-7 + error gradient border
- [x] Disabled: solid bg-default-3, opacity 50%
- [x] Icon prefix / suffix: icons visible, border intact around the whole group
- [x] Button suffix (password eye): button functional, border intact
- [x] Textarea with send button: same gradient border, auto height

🤖 Generated with [Claude Code](https://claude.com/claude-code)