### PR TITLE
Release v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ☀️ Solar UI
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-v0.5.0-blue.svg)](https://github.com/melvindesign/SolarUI/releases)
+[![Version](https://img.shields.io/badge/version-v0.6.0-blue.svg)](https://github.com/melvindesign/SolarUI/releases)
 [![Built with Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-v4-06B6D4?logo=tailwindcss&logoColor=white)](https://tailwindcss.com)
 [![shadcn/ui compatible](https://img.shields.io/badge/shadcn%2Fui-compatible-000000?logo=shadcnui&logoColor=white)](https://ui.shadcn.com)
 

--- a/content/overview/changelog.mdx
+++ b/content/overview/changelog.mdx
@@ -10,6 +10,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [v0.6.0] — 2026-04-07
+
+### Added
+- **Landing page** — New landing page with animated component showcase
+- **CI Registry Check** — GitHub Actions workflow to validate the registry on every push
+- **Favicon & Apple Icon** — Added site icons
+
+### Changed
+- **Registry** — Reorganized structure under `registry/solar/`
+
+### Fixed
+- **Alert** — Fixed registry entry
+- **Date Picker** — Fixed component and registry entry
+- **Dialog** — Fixed component and added missing registry dependencies
+- **Pagination** — Fixed component
+- **Select** — Fixed component
+- **Sheet** — Fixed component and added missing registry dependencies
+- **Sonner** — Added missing registry dependencies
+- **CI** — Removed duplicate component installation in workflow
+
+---
+
 ## [v0.5.0] — 2026-03-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solar-ui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "dev": "next",


### PR DESCRIPTION
## [v0.6.0] — 2026-04-07

### Added
- **Landing page** — New landing page with animated component showcase
- **CI Registry Check** — GitHub Actions workflow to validate the registry on every push
- **Favicon & Apple Icon** — Added site icons

### Changed
- **Registry** — Reorganized structure under `registry/solar/`

### Fixed
- **Alert** — Fixed registry entry
- **Date Picker** — Fixed component and registry entry
- **Dialog** — Fixed component and added missing registry dependencies
- **Pagination** — Fixed component
- **Select** — Fixed component
- **Sheet** — Fixed component and added missing registry dependencies
- **Sonner** — Added missing registry dependencies
- **CI** — Removed duplicate component installation in workflow